### PR TITLE
[UI] Add help button and link for enrollment and identity UIs

### DIFF
--- a/source/noid/noid.browser/enrollment.html
+++ b/source/noid/noid.browser/enrollment.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" type="text/css" href="style/bootstrap.min.css" />
+    <link rel="stylesheet" type="text/css" href="style/noid.css" />
     <link rel="stylesheet" type="text/css" href="style/noid_enrollment.css" />
     <link rel="stylesheet" type="text/css" href="style/font-awesome.min.css" />
     <script type="text/javascript" src="scripts/noid_enrollment.js"></script>
@@ -19,10 +20,10 @@
     </script>
 </head>
 <body>
-    <nav class="navbar navbar-default navbar-fixed-top  navbar-right">
+    <nav class="navbar navbar-default transparent navbar-fixed-top navbar-right">
         <div class="container">
             <ol class=" navbar-right">
-                <a href="#"><li class="glyphicon glyphicon-question-sign"></li> Help</a>
+                <a href="#"><li class="glyphicon glyphicon-question-sign"></li>  Help</a>
             </ol>
         </div>
     </nav>

--- a/source/noid/noid.browser/identity.html
+++ b/source/noid/noid.browser/identity.html
@@ -9,15 +9,16 @@
     <link rel="stylesheet" type="text/css" href="style/bootstrap.min.css" />
     <link rel="stylesheet" type="text/css" href="style/noid_identity.css" />
     <link rel="stylesheet" type="text/css" href="style/font-awesome.min.css" />
+    <link rel="stylesheet" type="text/css" href="style/noid.css" />
     <script type="text/javascript" src="scripts/noid_enrollment.js"></script>
     <script type="text/javascript" src="scripts/jquery-1.11.1.min.js"></script>
     <script type="text/javascript" src="scripts/bootstrap.min.js"></script>
 </head>
 <body>
-    <nav class="navbar navbar-default navbar-fixed-top  navbar-right">
+    <nav class=" navbar navbar-default transparent navbar-fixed-top navbar-right">
         <div class="container">
             <ol class=" navbar-right">
-                <a href="#"><li class="glyphicon glyphicon-question-sign"></li> Help</a>
+                <a href="#"><li class="glyphicon glyphicon-question-sign"></li>  Help</a>
             </ol>
         </div>
     </nav>

--- a/source/noid/noid.browser/style/noid.css
+++ b/source/noid/noid.browser/style/noid.css
@@ -1,0 +1,5 @@
+.navbar {
+    margin-top:3px;
+    background: none;
+    border-color: none;
+}


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Add help buttons to the enrollment and identity UI.
#### Does this PR resolve an open issue (reference issue #)?
Yes, Waffle #73 "As a user, I want access to help documentation"
#### Screenshots
Enrollment (see upper right corner)
![noid-enrollment-finger-scan-withhelp](https://cloud.githubusercontent.com/assets/7564876/22625206/8e2dbfec-eb55-11e6-9a0a-975c272a6b10.png)

Identity (see upper right corner)
![noid-identity-with-help](https://cloud.githubusercontent.com/assets/7564876/22625204/801be942-eb55-11e6-97c3-560dc4a8489c.png)