### PR TITLE
[UI] Remove NoID from portal page setup title

### DIFF
--- a/source/noid/noid.browser/enrollment.html
+++ b/source/noid/noid.browser/enrollment.html
@@ -694,7 +694,7 @@
                                 <div class="step11">
                                     <div class="row">
                                         <div class="jumbotron">
-                                            <h1>NoID Portal Password Setup</h1>
+                                            <h1>Portal Password Setup</h1>
                                             <h3>
                                                 Please enter in a password so you can access an audit of your NoID activities from any web enabled device. At login, you will be asked for this password, and a sms message containing a secure code will be sent to the phone number or email address on file. 
                                             </h3>


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Remove NoID from portal page setup title
#### Does this PR resolve an open issue (reference issue #)?
Waffle #75. "As a patient, I want to be able to setup my portal password during enrollment"
#### Screenshots:
![noid-enrollment-portal-setup-with-help2](https://cloud.githubusercontent.com/assets/7564876/22647302/579c5056-ec36-11e6-9d7d-ea392fbbe473.png)
