### PR TITLE
[UI] Add NAVIGATE preprocessor used to turn on browser nav controls

### DIFF
--- a/source/noid/noid.browser/browserform.cs
+++ b/source/noid/noid.browser/browserform.cs
@@ -2,7 +2,6 @@
 // Copyright © 2010-2015 The CefSharp Authors. All rights reserved.
 //
 // Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
-
 using System;
 using System.Windows.Forms;
 using NoID.Browser.Controls;
@@ -40,31 +39,38 @@ namespace NoID.Browser
             }
 
             browser = new ChromiumWebBrowser(endPath)
-
             {
                 Dock = DockStyle.Fill
             };
             toolStripContainer.ContentPanel.Controls.Add(browser);
 
-            browser.LoadingStateChanged += OnLoadingStateChanged;
-            browser.ConsoleMessage += OnBrowserConsoleMessage;
             browser.StatusMessage += OnBrowserStatusMessage;
             browser.TitleChanged += OnBrowserTitleChanged;
+#if NAVIGATE
+            browser.ConsoleMessage += OnBrowserConsoleMessage;
+            browser.LoadingStateChanged += OnLoadingStateChanged;
             browser.AddressChanged += OnBrowserAddressChanged;
 
             var bitness = Environment.Is64BitProcess ? "x64" : "x86";
             var version = String.Format("Chromium: {0}, CEF: {1}, CefSharp: {2}, Environment: {3}", Cef.ChromiumVersion, Cef.CefVersion, Cef.CefSharpVersion, bitness);
             DisplayOutput(version);
-        }
-
-        private void OnBrowserConsoleMessage(object sender, ConsoleMessageEventArgs args)
-        {
-            DisplayOutput(string.Format("Line: {0}, Source: {1}, Message: {2}", args.Line, args.Source, args.Message));
+#endif
         }
 
         private void OnBrowserStatusMessage(object sender, StatusMessageEventArgs args)
         {
             this.InvokeOnUiThreadIfRequired(() => statusLabel.Text = args.Value);
+        }
+
+        private void OnBrowserTitleChanged(object sender, TitleChangedEventArgs args)
+        {
+            this.InvokeOnUiThreadIfRequired(() => Text = args.Title);
+        }
+
+#if NAVIGATE
+        private void OnBrowserConsoleMessage(object sender, ConsoleMessageEventArgs args)
+        {
+            DisplayOutput(string.Format("Line: {0}, Source: {1}, Message: {2}", args.Line, args.Source, args.Message));
         }
 
         private void OnLoadingStateChanged(object sender, LoadingStateChangedEventArgs args)
@@ -75,16 +81,11 @@ namespace NoID.Browser
             this.InvokeOnUiThreadIfRequired(() => SetIsLoading(!args.CanReload));
         }
 
-        private void OnBrowserTitleChanged(object sender, TitleChangedEventArgs args)
-        {
-            this.InvokeOnUiThreadIfRequired(() => Text = args.Title);
-        }
-
         private void OnBrowserAddressChanged(object sender, AddressChangedEventArgs args)
         {
             this.InvokeOnUiThreadIfRequired(() => urlTextBox.Text = args.Address);
         }
-
+        
         private void SetCanGoBack(bool canGoBack)
         {
             this.InvokeOnUiThreadIfRequired(() => backButton.Enabled = canGoBack);
@@ -94,7 +95,7 @@ namespace NoID.Browser
         {
             this.InvokeOnUiThreadIfRequired(() => forwardButton.Enabled = canGoForward);
         }
-
+        
         private void SetIsLoading(bool isLoading)
         {
             goButton.Text = isLoading ?
@@ -106,7 +107,7 @@ namespace NoID.Browser
 
             HandleToolStripLayout();
         }
-
+        
         public void DisplayOutput(string output)
         {
             this.InvokeOnUiThreadIfRequired(() => outputLabel.Text = output);
@@ -116,7 +117,7 @@ namespace NoID.Browser
         {
             HandleToolStripLayout();
         }
-
+        
         private void HandleToolStripLayout()
         {
             var width = toolStrip1.Width;
@@ -129,7 +130,7 @@ namespace NoID.Browser
             }
             urlTextBox.Width = Math.Max(0, width - urlTextBox.Margin.Horizontal - 18);
         }
-
+        
         private void ExitMenuItemClick(object sender, EventArgs e)
         {
             browser.Dispose();
@@ -151,7 +152,7 @@ namespace NoID.Browser
         {
             browser.Forward();
         }
-
+        
         private void UrlTextBoxKeyUp(object sender, KeyEventArgs e)
         {
             if (e.KeyCode != Keys.Enter)
@@ -169,5 +170,6 @@ namespace NoID.Browser
                 browser.Load(url);
             }
         }
+#endif
     }
 }

--- a/source/noid/noid.browser/browserform.designer.cs
+++ b/source/noid/noid.browser/browserform.designer.cs
@@ -33,18 +33,18 @@
             this.statusLabel = new System.Windows.Forms.Label();
             this.outputLabel = new System.Windows.Forms.Label();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+#if NAVIGATE
+    
+
             this.backButton = new System.Windows.Forms.ToolStripButton();
             this.forwardButton = new System.Windows.Forms.ToolStripButton();
             this.urlTextBox = new System.Windows.Forms.ToolStripTextBox();
             this.goButton = new System.Windows.Forms.ToolStripButton();
-            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+#endif
             this.toolStripContainer.ContentPanel.SuspendLayout();
             this.toolStripContainer.TopToolStripPanel.SuspendLayout();
             this.toolStripContainer.SuspendLayout();
             this.toolStrip1.SuspendLayout();
-            this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // toolStripContainer
@@ -90,21 +90,25 @@
             // 
             this.toolStrip1.Dock = System.Windows.Forms.DockStyle.None;
             this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+#if NAVIGATE
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.backButton,
             this.forwardButton,
             this.urlTextBox,
             this.goButton});
+#endif
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
             this.toolStrip1.Name = "toolStrip1";
             this.toolStrip1.Padding = new System.Windows.Forms.Padding(0);
             this.toolStrip1.Size = new System.Drawing.Size(730, 25);
             this.toolStrip1.Stretch = true;
             this.toolStrip1.TabIndex = 0;
-            this.toolStrip1.Layout += new System.Windows.Forms.LayoutEventHandler(this.HandleToolStripLayout);
+#if NAVIGATE
+            //this.toolStrip1.Layout += new System.Windows.Forms.LayoutEventHandler(this.HandleToolStripLayout);
             // 
             // backButton
-            // 
+            //
+
             this.backButton.Enabled = false;
             this.backButton.Image = global::NoID.Browser.Properties.Resources.nav_left_green;
             this.backButton.ImageTransparentColor = System.Drawing.Color.Magenta;
@@ -138,31 +142,7 @@
             this.goButton.Size = new System.Drawing.Size(42, 22);
             this.goButton.Text = "Go";
             this.goButton.Click += new System.EventHandler(this.GoButtonClick);
-            // 
-            // menuStrip1
-            // 
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.fileToolStripMenuItem});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(730, 24);
-            this.menuStrip1.TabIndex = 1;
-            this.menuStrip1.Text = "menuStrip1";
-            // 
-            // fileToolStripMenuItem
-            // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.exitToolStripMenuItem});
-            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            this.fileToolStripMenuItem.Text = "File";
-            // 
-            // exitToolStripMenuItem
-            // 
-            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
-            this.exitToolStripMenuItem.Text = "Exit";
-            this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitMenuItemClick);
+#endif
             // 
             // BrowserForm
             // 
@@ -170,11 +150,9 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(730, 490);
             this.Controls.Add(this.toolStripContainer);
-            this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this.menuStrip1;
-            this.Name = "BrowserForm";
-            this.Text = "BrowserForm";
+            this.Name = "browserForm";
+            this.Text = "NoID Main Window";
             this.toolStripContainer.ContentPanel.ResumeLayout(false);
             this.toolStripContainer.ContentPanel.PerformLayout();
             this.toolStripContainer.TopToolStripPanel.ResumeLayout(false);
@@ -183,26 +161,22 @@
             this.toolStripContainer.PerformLayout();
             this.toolStrip1.ResumeLayout(false);
             this.toolStrip1.PerformLayout();
-            this.menuStrip1.ResumeLayout(false);
-            this.menuStrip1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
 
-        #endregion
+#endregion
 
         private System.Windows.Forms.ToolStripContainer toolStripContainer;
         private System.Windows.Forms.ToolStrip toolStrip1;
+        private System.Windows.Forms.Label outputLabel;
+        private System.Windows.Forms.Label statusLabel;
+#if NAVIGATE
         private System.Windows.Forms.ToolStripButton backButton;
         private System.Windows.Forms.ToolStripButton forwardButton;
         private System.Windows.Forms.ToolStripTextBox urlTextBox;
         private System.Windows.Forms.ToolStripButton goButton;
-        private System.Windows.Forms.MenuStrip menuStrip1;
-        private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
-        private System.Windows.Forms.Label outputLabel;
-        private System.Windows.Forms.Label statusLabel;
-
+#endif
     }
 }

--- a/source/noid/noid.browser/noid.browser.csproj
+++ b/source/noid/noid.browser/noid.browser.csproj
@@ -60,6 +60,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <DefineConstants>#define NAVIGATE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Added NAVIGATE preprocessor directive used to turn on/off browser navigation controls
#### Screenshots:
##### With Controls
![noid-with-browser-nav](https://cloud.githubusercontent.com/assets/7564876/22861250/f8d14da8-f0d9-11e6-8d75-9a8124c4c3be.png)

##### Without Controls
![noid-without-nav](https://cloud.githubusercontent.com/assets/7564876/22861254/23227cf8-f0da-11e6-8eb3-d79c66146e22.png)



