### PR TITLE
Enable English only in patient gui language selection

### DIFF
--- a/source/noid.html/enrollment.html
+++ b/source/noid.html/enrollment.html
@@ -889,9 +889,9 @@
                             <div class="col-md-8 col-xs-9">
                                 <select name="visa_status" id="visa_status" class="dropselectsec1">
                                     <option value="English">English</option>
-                                    <option value="Español">Español</option>
-                                    <option value="François">François</option>
-                                    <option value="Deutsch">Deutsch</option>
+                                    <option disabled title="Spanish Translation Not Supported for Prototype" value="Español">Español</option>
+                                    <option disabled title="French Translation Not Supported for Prototype" value="François">François</option>
+                                    <option disabled title="German Translation Not Supported for Prototype" value="Deutsch">Deutsch</option>
                                 </select>
                             </div>
                         </div>


### PR DESCRIPTION
Enable English only in patient gui language selection. Disabled all non-English options and added "Not for prototype" discaimers.